### PR TITLE
Add a command to help assist with gem set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,42 +26,56 @@ gem install slack_messaging
 
 This project requires a config file that should look like this:
 
-```
+```yml
 slack:
   channel: <AWESOME CHANNEL NAME>
   username: <AWESOME USER NAME>
   webhook_url: <SLACK WEBHOOK URL>
-  icon_emoji: ":<SOME EMOJI>:"
+  icon_emoji: ':<SOME EMOJI>:'
 ```
 
-The default is for the file to be named `~/.slack_messaging.yml`, but a different path can be passed in like this:
+To generate this file at `~/.slack_messaging.yml`, please run this command:
 
+```bash
+slack-messaging setup
 ```
-$ slack-messaging --config="/PATH/TO/FILE/config.yml" slack
+
+If you'd like to create the config file at a different directory, I recommend using the `setup` command, and then manually moving the file to your desired location:
+
+```bash
+slack-messaging setup
+# Walk through the prompts to create the file
+mv ~/.slack_messaging.yml /PATH/TO/FILE/config.yml
 ```
 
-To obtain the webhook url, go to [this link](https://api.slack.com/incoming-webhooks).
+And then you can pass in that specific file location like this:
 
-Okay, now the project will be ready to rock and roll.
+```bash
+slack-messaging --config="/PATH/TO/FILE/config.yml" slack
+```
+
+To obtain the webhook URL, go to [this link](https://api.slack.com/messaging/webhooks).
+
+Once the config file is set up, the project is ready to go!
 
 To print a friendly message to Slack, run:
 
-```
+```bash
 slack-messaging slack
 ```
 
-from the main directory. Here, no specific message is being given to print to Slack, so slack_messaging will choose a random quote. The random quotes are selected using the [Quotable API](http://api.quotable.io/).
+Here, no specific message is being given to print to Slack, so slack_messaging will choose a random quote. The random quotes are selected using the [Quotable API](http://api.quotable.io/).
 
 However, what if you wanted to print something specific? Well, you can! Just run:
 
-```
-slack-messaging slack "MESSAGE 1"
+```bash
+slack-messaging slack 'MESSAGE 1'
 ```
 
 You can even print multiple messages at once:
 
-```
-slack-messaging slack "MESSAGE 1" "MESSAGE 2" "MESSAGE 3" ... "MESSAGE N"
+```bash
+slack-messaging slack 'MESSAGE 1' 'MESSAGE 2' 'MESSAGE 3' ... 'MESSAGE N'
 ```
 
 The output of slack_messaging will look something like this:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ To generate this file at `~/.slack_messaging.yml`, please run this command:
 slack-messaging setup
 ```
 
+To obtain the webhook URL, go to [this link](https://api.slack.com/messaging/webhooks).
+
 If you'd like to create the config file at a different directory, I recommend using the `setup` command, and then manually moving the file to your desired location:
 
 ```bash
@@ -53,8 +55,6 @@ And then you can pass in that specific file location like this:
 ```bash
 slack-messaging --config="/PATH/TO/FILE/config.yml" slack
 ```
-
-To obtain the webhook URL, go to [this link](https://api.slack.com/messaging/webhooks).
 
 Once the config file is set up, the project is ready to go!
 

--- a/bin/slack-messaging
+++ b/bin/slack-messaging
@@ -14,6 +14,8 @@ flag [:config], :desc => 'Slack Messaging config file path', :default_value => S
 
 program_long_desc """
 DOCUMENTATION
+    For documentation and help in setting up your configuration files,
+    see Slack Messaging's GitHub repo: https://github.com/emmahsax/slack_messaging
 """
 
 desc 'Prints a variety of messages to Slack'

--- a/bin/slack-messaging
+++ b/bin/slack-messaging
@@ -10,7 +10,7 @@ version SlackMessaging::VERSION
 
 wrap_help_text :verbatim
 
-flag [:config], :desc => 'SlackMessaging config file path', :default_value => SlackMessaging::DefaultPaths.config
+flag [:config], :desc => 'Slack Messaging config file path', :default_value => SlackMessaging::DefaultPaths.config
 
 program_long_desc """
 DOCUMENTATION
@@ -18,15 +18,21 @@ DOCUMENTATION
 
 desc 'Prints a variety of messages to Slack'
 command 'slack' do |c|
+  pre do |global, command, options, args|
+    SlackMessaging::Config.load(global[:config])
+    true
+  end
+
   c.action do |global_options, options, args|
     SlackMessaging::Slack.execute(args, options)
   end
 end
 
-pre do |global,command,options,args|
-  SlackMessaging::Config.load(global[:config])
-  SlackMessaging::Config.set_config_options(global)
-  true
+desc 'Sets up a Slack Messaging config file at ~/.slack_messaging.yml'
+command 'setup' do |c|
+  c.action do ||
+    SlackMessaging::Setup.execute
+  end
 end
 
 exit run(ARGV)

--- a/lib/slack_messaging/highline_cli.rb
+++ b/lib/slack_messaging/highline_cli.rb
@@ -1,0 +1,33 @@
+module SlackMessaging
+  class HighlineCli
+    def ask(prompt)
+      highline_client.ask(prompt) do |conf|
+        conf.readline = true
+      end.to_s
+    end
+
+    def ask_yes_no(prompt)
+      answer = highline_client.ask(prompt) do |conf|
+        conf.readline = true
+      end.to_s
+
+      answer.empty? ? true : !!(answer =~ /^y/i)
+    end
+
+    def ask_options(prompt, choices)
+      choices_as_string_options = ''
+      choices.each { |choice| choices_as_string_options << "#{choices.index(choice) + 1}. #{choice}\n" }
+      compiled_prompt = "#{prompt}\n#{choices_as_string_options.strip}"
+
+      index = highline_client.ask(compiled_prompt) do |conf|
+        conf.readline = true
+      end.to_i - 1
+
+      choices[index]
+    end
+
+    private def highline_client
+      @highline_client ||= HighLine.new
+    end
+  end
+end

--- a/lib/slack_messaging/setup.rb
+++ b/lib/slack_messaging/setup.rb
@@ -40,7 +40,9 @@ module SlackMessaging
       answers = {}
 
       answers[:webhook_url] = ask_question(
-        "\nWhat is your Slack webhook URL? If you don't have one yet, please navigate to https://api.slack.com/messaging/webhooks to create one, and then come back here and paste it in the Terminal."
+        "\nWhat is your Slack webhook URL? If you don't have one yet, please navigate" \
+        " to https://api.slack.com/messaging/webhooks to create one, and then come back" \
+        " here and paste it in the Terminal."
       )
 
       unless answers[:webhook_url]

--- a/lib/slack_messaging/setup.rb
+++ b/lib/slack_messaging/setup.rb
@@ -1,0 +1,79 @@
+module SlackMessaging
+  class Setup
+    def self.execute
+      if config_file_exists?
+        answer = highline.ask_yes_no("It looks like the #{default_config} file already exists. Do you wish to replace it? (y/n)")
+
+        unless answer
+          puts "\nExiting because you selected to not replace the #{default_config} file..."
+          exit
+        end
+      end
+
+      create_or_update_config_file(ask_config_questions)
+    end
+
+    private
+
+    def self.create_or_update_config_file(answers)
+      contents = generate_config_file(answers)
+      puts "\nCreating or updating your #{default_config} file..."
+      File.open(default_config, 'w') { |file| file.puts contents }
+      puts "\nDone!"
+    end
+
+    def self.generate_config_file(answers)
+      file_contents = ''
+      file_contents << "slack:\n"
+      file_contents << "  channel: #{answers[:channel].tr('#', '').strip}\n"
+      file_contents << "  username: #{answers[:username].strip}\n"
+      file_contents << "  webhook_url: #{answers[:webhook_url].strip}\n"
+      file_contents << "  icon_emoji: '#{answers[:icon_emoji].strip}'"
+      file_contents
+    end
+
+    def self.config_file_exists?
+      File.exists?(default_config)
+    end
+
+    def self.ask_config_questions
+      answers = {}
+
+      answers[:webhook_url] = ask_question(
+        "\nWhat is your Slack webhook URL? If you don't have one yet, please navigate to https://api.slack.com/messaging/webhooks to create one, and then come back here and paste it in the Terminal."
+      )
+
+      unless answers[:webhook_url]
+        puts "\nExiting because Slack webhoook is required..."
+        exit
+      end
+
+      answers[:channel] = ask_question(
+        "\nWhat slack channel do you wish to post to? (default is \"#general\")"
+      ) || 'general'
+
+      answers[:username] = ask_question(
+        "\nWhat slack username do you wish to post as? (default is \"Let's Get Quoty\")"
+      ) || "Let's Get Quoty"
+
+      answers[:icon_emoji] = ask_question(
+        "\nWhat emoji would you like to post with (include the colons at the beginning and end of the emoji name)? (default is \":mailbox_with_mail:\")"
+      ) || ":mailbox_with_mail:"
+
+      answers
+    end
+
+    def self.ask_question(prompt)
+      answer = highline.ask(prompt)
+      answer.empty? ? nil : answer
+    end
+
+    def self.highline
+      @highline ||= SlackMessaging::HighlineCli.new
+    end
+
+    def self.default_config
+      SlackMessaging::DefaultPaths.config
+    end
+  end
+end

--- a/lib/slack_messaging/version.rb
+++ b/lib/slack_messaging/version.rb
@@ -1,3 +1,3 @@
 module SlackMessaging
-  VERSION = '2.1.1'
+  VERSION = '2.2.0'
 end

--- a/spec/slack_messaging/config_spec.rb
+++ b/spec/slack_messaging/config_spec.rb
@@ -2,16 +2,18 @@ require 'spec_helper'
 require 'slack_messaging'
 
 describe SlackMessaging::Config do
+  subject { SlackMessaging::Config }
+
   context 'config key methods' do
     it 'should return nil when not set' do
-      expect(SlackMessaging::Config.doesnt_exist).to eql(nil)
-      expect(SlackMessaging::Config.doesnt_exist?).to eql(false)
+      expect(subject.doesnt_exist).to eql(nil)
+      expect(subject.doesnt_exist?).to eql(false)
     end
 
     it 'should return the config value when set' do
       config_value = Faker::Lorem.word
-      SlackMessaging::Config.new_value = config_value
-      expect(SlackMessaging::Config.new_value).to eql(config_value)
+      subject.new_value = config_value
+      expect(subject.new_value).to eql(config_value)
     end
   end
 
@@ -35,19 +37,19 @@ describe SlackMessaging::Config do
     before do
       allow(YAML).to receive(:load_file).and_return(config_file)
       allow(File).to receive(:exist?).and_return(true)
-      SlackMessaging::Config.load(Faker::Lorem.word)
+      subject.load(Faker::Lorem.word)
     end
 
     it 'calling a method corresponding to a key in the file should return the value' do
-      expect(SlackMessaging::Config.domain).to eql(domain)
-      expect(SlackMessaging::Config.slack).to be_kind_of(Hash)
-      expect(SlackMessaging::Config.slack[:slack_option]).to eql(true)
+      expect(subject.domain).to eql(domain)
+      expect(subject.slack).to be_kind_of(Hash)
+      expect(subject.slack[:slack_option]).to eql(true)
     end
 
     it 'overwriting values should work' do
-      expect(SlackMessaging::Config.slack).to be_kind_of(Hash)
-      SlackMessaging::Config.slack = sentence
-      expect(SlackMessaging::Config.slack).to eql(sentence)
+      expect(subject.slack).to be_kind_of(Hash)
+      subject.slack = sentence
+      expect(subject.slack).to eql(sentence)
     end
   end
 end

--- a/spec/slack_messaging/highline_cli_spec.rb
+++ b/spec/slack_messaging/highline_cli_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'slack_messaging'
+
+describe SlackMessaging::HighlineCli do
+  let(:response) { double(:response, readline: true, to_i: 3) }
+  let(:highline_client) { double(:highline_cli, ask: response) }
+
+  before do
+    allow(HighLine).to receive(:new).and_return(highline_client)
+  end
+
+  describe '#ask' do
+    it 'should ask the highline client ask'do
+      expect(highline_client).to receive(:ask)
+      subject.ask(Faker::Lorem.sentence)
+    end
+
+    it 'should return a string' do
+      expect(subject.ask(Faker::Lorem.sentence)).to be_a(String)
+    end
+  end
+
+  describe '#ask_yes_no' do
+    it 'should ask the highline client ask'do
+      expect(highline_client).to receive(:ask)
+      subject.ask_yes_no(Faker::Lorem.sentence)
+    end
+
+    it 'should return a boolean' do
+      expect(subject.ask_yes_no(Faker::Lorem.sentence)).to be_falsey
+    end
+
+    it 'should return true if we say yes' do
+      allow(response).to receive(:to_s).and_return('y')
+      expect(subject.ask_yes_no(Faker::Lorem.sentence)).to be_truthy
+    end
+  end
+
+  describe '#ask_options' do
+    it 'should ask the highline client ask'do
+      expect(highline_client).to receive(:ask)
+      subject.ask_options(Faker::Lorem.sentence, ['one', 'two', 'three'])
+    end
+
+    it 'should return a string from the options' do
+      expect(subject.ask_options(Faker::Lorem.sentence, ['one', 'two', 'three'])).to be_a(String)
+    end
+  end
+end

--- a/spec/slack_messaging/notify_slack_spec.rb
+++ b/spec/slack_messaging/notify_slack_spec.rb
@@ -26,14 +26,16 @@ describe SlackMessaging::NotifySlack do
     SlackMessaging::Config.load(Faker::Lorem.word)
   end
 
+  subject { SlackMessaging::NotifySlack }
+
   it 'should call HTTParty' do
     expect(HTTParty).to receive(:post)
-    message = SlackMessaging::NotifySlack.new(sentence)
+    message = subject.new(sentence)
     message.perform
   end
 
     it 'should define certain values' do
-    message = SlackMessaging::NotifySlack.new(sentence)
+    message = subject.new(sentence)
     expect(message.text).to eq(sentence)
     expect(message.channel).to eq(channel)
     expect(message.username).to eq(username)

--- a/spec/slack_messaging/random_message_spec.rb
+++ b/spec/slack_messaging/random_message_spec.rb
@@ -16,28 +16,30 @@ describe SlackMessaging::RandomMessage do
     allow(HTTParty).to receive(:get).and_return(quote_object)
   end
 
+  subject { SlackMessaging::RandomMessage }
+
   it 'should get a string message' do
-    message = SlackMessaging::RandomMessage.acquire_random_quote
+    message = subject.acquire_random_quote
     expect(message).to be_instance_of(String)
   end
 
   it 'should get a message that includes a newline' do
-    message = SlackMessaging::RandomMessage.acquire_random_quote
+    message = subject.acquire_random_quote
     expect(message.include?("\n")).to eq(true)
   end
 
   it 'should get a message that includes a —' do
-    message = SlackMessaging::RandomMessage.acquire_random_quote
+    message = subject.acquire_random_quote
     expect(message.include?('—')).to eq(true)
   end
 
   it 'should use HTTParty to ping an API' do
     expect(HTTParty).to receive(:get)
-    SlackMessaging::RandomMessage.acquire_random_quote
+    subject.acquire_random_quote
   end
 
   it 'should have the JSON parse the response content twice' do
     expect(JSON).to receive(:parse).at_least(2).times.and_return(JSON.parse(quote_json))
-    SlackMessaging::RandomMessage.acquire_random_quote
+    subject.acquire_random_quote
   end
 end

--- a/spec/slack_messaging/setup_spec.rb
+++ b/spec/slack_messaging/setup_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'slack_messaging'
+
+describe SlackMessaging::Setup do
+  let(:response) { double(:response, readline: true, to_s: Faker::Lorem.sentence) }
+  let(:highline_client) { double(:highline_cli, ask: response, ask_yes_no: true) }
+
+  before do
+    allow(HighLineCli).to receive(:new).and_return(highline_client)
+  end
+end

--- a/spec/slack_messaging/setup_spec.rb
+++ b/spec/slack_messaging/setup_spec.rb
@@ -15,6 +15,7 @@ describe SlackMessaging::Setup do
 
   before do
     allow(SlackMessaging::HighlineCli).to receive(:new).and_return(highline_cli)
+    allow(subject).to receive(:puts)
   end
 
   after do

--- a/spec/slack_messaging/setup_spec.rb
+++ b/spec/slack_messaging/setup_spec.rb
@@ -49,7 +49,7 @@ describe SlackMessaging::Setup do
     end
   end
 
-  describe '#create_or_update_config_file' do
+  describe '#self.create_or_update_config_file' do
     it 'should generate the file based on the answers to the questions' do
       expect(subject).to receive(:generate_config_file)
       allow(File).to receive(:open).and_return(nil)
@@ -63,13 +63,13 @@ describe SlackMessaging::Setup do
     end
   end
 
-  describe '#generate_config_file' do
+  describe '#self.generate_config_file' do
     it 'returns a string' do
       expect(subject.send(:generate_config_file, answers)).to be_a(String)
     end
   end
 
-  describe '#config_file_exists?' do
+  describe '#self.config_file_exists?' do
     it 'should return true if the file exists' do
       allow(File).to receive(:exists?).and_return(true)
       expect(subject.send(:config_file_exists?)).to eq(true)
@@ -81,7 +81,7 @@ describe SlackMessaging::Setup do
     end
   end
 
-  describe '#ask_question' do
+  describe '#self.ask_question' do
     it 'should use highline to ask a question' do
       expect(highline_cli).to receive(:ask).and_return('')
       subject.send(:ask_question, Faker::Lorem.sentence)
@@ -99,7 +99,7 @@ describe SlackMessaging::Setup do
     end
   end
 
-  describe '#ask_config_questions' do
+  describe '#self.ask_config_questions' do
     it 'should call to ask at least four questions' do
       expect(subject).to receive(:ask_question).at_least(4).times
       subject.send(:ask_config_questions)

--- a/spec/slack_messaging/setup_spec.rb
+++ b/spec/slack_messaging/setup_spec.rb
@@ -9,7 +9,7 @@ describe SlackMessaging::Setup do
       channel: Faker::Lorem.word,
       username: Faker::Lorem.word,
       webhook_url: Faker::Internet.url,
-      icon_emoji: "#{Faker::Lorem.word}:"
+      icon_emoji: ":#{Faker::Lorem.word}:"
     }
   end
 

--- a/spec/slack_messaging/setup_spec.rb
+++ b/spec/slack_messaging/setup_spec.rb
@@ -3,9 +3,129 @@ require 'slack_messaging'
 
 describe SlackMessaging::Setup do
   let(:response) { double(:response, readline: true, to_s: Faker::Lorem.sentence) }
-  let(:highline_client) { double(:highline_cli, ask: response, ask_yes_no: true) }
+  let(:highline_cli) { double(:highline_cli, ask: response, ask_yes_no: true) }
+  let(:answers) do
+    {
+      channel: Faker::Lorem.word,
+      username: Faker::Lorem.word,
+      webhook_url: Faker::Internet.url,
+      icon_emoji: "#{Faker::Lorem.word}:"
+    }
+  end
 
   before do
-    allow(HighLineCli).to receive(:new).and_return(highline_client)
+    allow(SlackMessaging::HighlineCli).to receive(:new).and_return(highline_cli)
+  end
+
+  after do
+    SlackMessaging::Setup.instance_variable_set("@highline", nil)
+  end
+
+  subject { SlackMessaging::Setup }
+
+  describe '#self.execute' do
+    it 'should ask a question if the config file exists' do
+      allow(File).to receive(:exists?).and_return(true)
+      expect(highline_cli).to receive(:ask_yes_no).and_return(true)
+      allow(subject).to receive(:create_or_update_config_file).and_return(true)
+      allow(subject).to receive(:ask_config_questions).and_return(true)
+      subject.execute
+    end
+
+    it 'should call to create or update the config file' do
+      allow(File).to receive(:exists?).and_return(true)
+      allow(highline_cli).to receive(:ask_yes_no).and_return(true)
+      expect(subject).to receive(:create_or_update_config_file).and_return(true)
+      expect(subject).to receive(:ask_config_questions).and_return(true)
+      subject.execute
+    end
+
+    it 'should exit if the user opts not to continue' do
+      allow(File).to receive(:exists?).and_return(true)
+      allow(highline_cli).to receive(:ask_yes_no).and_return(false)
+      expect(subject).not_to receive(:create_or_update_config_file)
+      expect(subject).not_to receive(:ask_config_questions)
+      expect{ subject.execute }.to raise_error(SystemExit)
+    end
+  end
+
+  describe '#create_or_update_config_file' do
+    it 'should generate the file based on the answers to the questions' do
+      expect(subject).to receive(:generate_config_file)
+      allow(File).to receive(:open).and_return(nil)
+      subject.send(:create_or_update_config_file, answers)
+    end
+
+    it 'should open the file for writing' do
+      allow(subject).to receive(:generate_config_file)
+      expect(File).to receive(:open).and_return(nil)
+      subject.send(:create_or_update_config_file, answers)
+    end
+  end
+
+  describe '#generate_config_file' do
+    it 'returns a string' do
+      expect(subject.send(:generate_config_file, answers)).to be_a(String)
+    end
+  end
+
+  describe '#config_file_exists?' do
+    it 'should return true if the file exists' do
+      allow(File).to receive(:exists?).and_return(true)
+      expect(subject.send(:config_file_exists?)).to eq(true)
+    end
+
+    it 'should return false if the file does not exist' do
+      allow(File).to receive(:exists?).and_return(false)
+      expect(subject.send(:config_file_exists?)).to eq(false)
+    end
+  end
+
+  describe '#ask_question' do
+    it 'should use highline to ask a question' do
+      expect(highline_cli).to receive(:ask).and_return('')
+      subject.send(:ask_question, Faker::Lorem.sentence)
+    end
+
+    it 'should return nil if the highline client gets an empty string' do
+      allow(highline_cli).to receive(:ask).and_return('')
+      expect(subject.send(:ask_question, Faker::Lorem.sentence)).to be_nil
+    end
+
+    it 'should return the answer if it is given' do
+      answer = Faker::Lorem.sentence
+      allow(highline_cli).to receive(:ask).and_return(answer)
+      expect(subject.send(:ask_question, Faker::Lorem.sentence)).to be(answer)
+    end
+  end
+
+  describe '#ask_config_questions' do
+    it 'should call to ask at least four questions' do
+      expect(subject).to receive(:ask_question).at_least(4).times
+      subject.send(:ask_config_questions)
+    end
+
+    it 'should exit if the slack URL is not given' do
+      allow(subject).to receive(:ask_question).and_return(nil)
+      expect{ subject.send(:ask_config_questions) }.to raise_error(SystemExit)
+    end
+
+    it 'should return the defaults if nothing is given' do
+      slack_url = Faker::Internet.url
+      allow(subject).to receive(:ask_question).with(
+        "\nWhat is your Slack webhook URL? If you don't have one yet, please navigate" \
+        " to https://api.slack.com/messaging/webhooks to create one, and then come back" \
+        " here and paste it in the Terminal."
+      ).and_return(slack_url)
+      allow(subject).to receive(:ask_question).and_return(nil)
+      expect(subject.send(:ask_config_questions)).to eq(
+        {
+          channel: 'general',
+          username: "Let's Get Quoty",
+          webhook_url: slack_url,
+          icon_emoji: ":mailbox_with_mail:"
+        }
+      )
+    end
   end
 end


### PR DESCRIPTION
## Changes

Add a new command `setup` which can be used to set up the initial `~/.slack_messaging.yml` config file. Call it like this:

```bash
slack-messaging setup
```

This PR also adds tests for it and cleans up some other code around the commands.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.
