### PR TITLE
Replace 'Switch to Current Branch' with 'Check Out Code'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Check Out Code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
     - name: Set Environment Variables
       run: |
         if [[ ${{ github.REF }} == 'refs/heads'* ]]; then # this is a branch, not a pull request
@@ -22,8 +17,10 @@ jobs:
           echo "BRANCH=$(echo ${{ github.HEAD_REF }} | sed -E 's|refs/[a-zA-Z]+/||')" >> $GITHUB_ENV
         fi
 
-    - name: Switch to Current Branch
-      run: git checkout ${{ env.BRANCH }}
+    - name: Check Out Code
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.BRANCH }}
 
     - name: Install Ruby and Bundle Install
       uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - vendor/**/*
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ AllCops:
   Exclude:
     - vendor/**/*
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true
 


### PR DESCRIPTION
## Changes

Move the `'Check Out Code'` step of the GitHub Actions workflow below the definition of the branch so that we can skip the `'Switch to Current Branch'`.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
