### PR TITLE
Remove unnecessary gem dependencies

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -2,6 +2,6 @@
 
 guard :rspec, cmd: 'bundle exec rspec', all_on_start: true do
   watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { 'spec' }
 end

--- a/lib/slack_messaging/version.rb
+++ b/lib/slack_messaging/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SlackMessaging
-  VERSION = '3.1.3'
+  VERSION = '3.2.0'
 end

--- a/slack_messaging.gemspec
+++ b/slack_messaging.gemspec
@@ -6,8 +6,9 @@ Gem::Specification.new do |gem|
   gem.name                  = 'slack_messaging'
   gem.version               = SlackMessaging::VERSION
   gem.authors               = ['Emma Sax']
-  gem.summary               = 'Personalized Slack Messages'
-  gem.description           = 'Sending Personalized Slack Messages to a Slack channel of your choice.'
+  gem.summary               = 'Personalized quotes and messages sent straight to Slack'
+  gem.description           = 'Sending personalized messages and quotes to a Slack channel of your ' \
+                              'choice via the command-line.'
   gem.homepage              = 'https://github.com/emmahsax/slack_messaging'
   gem.license               = 'BSD-3-Clause'
   gem.required_ruby_version = '>= 2.4'
@@ -19,19 +20,16 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir['spec/spec_helper.rb'] + Dir['spec/slack_messaging/*.rb']
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activesupport', '~> 6.0'
   gem.add_dependency 'gli', '~> 2.10'
   gem.add_dependency 'hashie', '~> 4.1'
   gem.add_dependency 'highline_wrapper', '~> 1.1'
   gem.add_dependency 'httparty', '~> 0.18'
   gem.add_dependency 'json', '~> 2.5'
-  gem.add_dependency 'rack', '~> 2.2'
 
   gem.add_development_dependency 'bundler', '~> 2.2'
   gem.add_development_dependency 'faker', '~> 2.15'
   gem.add_development_dependency 'guard-rspec', '~> 4.3'
   gem.add_development_dependency 'pry', '~> 0.13'
-  gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency 'rspec', '~> 3.9'
   gem.add_development_dependency 'rubocop', '~> 1.10'
 end


### PR DESCRIPTION
## Changes

* Remove the `rake` development dependency because it's not really required
* Remove the `activesupport` and `rack` dependencies because those aren't required either
* Correctly watch the `lib` files when using Guard
* Update the gem's description and summary

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
