### PR TITLE
Allow a higher version of the hashie gem

### DIFF
--- a/lib/slack_messaging/version.rb
+++ b/lib/slack_messaging/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SlackMessaging
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end

--- a/slack_messaging.gemspec
+++ b/slack_messaging.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'gli', '~> 2.10'
-  gem.add_dependency 'hashie', '~> 4.1'
+  gem.add_dependency 'hashie', '~> 4.1', '<= 5'
   gem.add_dependency 'highline_wrapper', '~> 1.1'
   gem.add_dependency 'httparty', '~> 0.18'
   gem.add_dependency 'json', '~> 2.5'


### PR DESCRIPTION
## Changes

Allow a higher version of the `hashie` gem since a new major version came out.

QA should involve testing a new release of the gem locally to make sure it still outputs into Slack. Also, we should test the `setup` command continues to work.
