### PR TITLE
Support higher version of faker in development

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,7 +10,7 @@ env:
   GITLEAKS_CONFIG_COMMITS: "[]"
   GITLEAKS_CONFIG_PATHS: "[]"
   GITLEAKS_CONFIG_REGEXES: "[]"
-  GITLEAKS_VERSION: v8.10.2
+  GITLEAKS_VERSION: v8.15.0
   RUN_DEFAULT_ON_ALL_COMMITS: 'true'
 
 ###########################################################

--- a/slack_messaging.gemspec
+++ b/slack_messaging.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'json', '~> 2.5'
 
   gem.add_development_dependency 'bundler', '~> 2.2'
-  gem.add_development_dependency 'faker', '~> 2.15'
+  gem.add_development_dependency 'faker', '~> 3.0'
   gem.add_development_dependency 'guard-rspec', '~> 4.3'
   gem.add_development_dependency 'pry', '~> 0.13'
   gem.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
## Changes

* Support a higher level of the `faker` gem in development mode
* Update GitLeaks to the newest patch version in development

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
